### PR TITLE
declare pod is UTF-8

### DIFF
--- a/lib/Unicode/EastAsianWidth.pm
+++ b/lib/Unicode/EastAsianWidth.pm
@@ -427,6 +427,8 @@ END
 
 __END__
 
+=encoding UTF-8
+
 =head1 NAME
 
 Unicode::EastAsianWidth - East Asian Width properties


### PR DESCRIPTION
The Pod is already UTF-8 encoded, but the lack of an `=encoding` declaration is causing problems with some Pod formatters like MetaCPAN.

https://metacpan.org/pod/Unicode::EastAsianWidth#CC0-1.0-Universal
